### PR TITLE
Update Readme.md adding small add for Ubuntu

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -161,6 +161,7 @@ and instrument your .NET application using the provided Shell scripts.
 
 > **Note**
 > On macOS [`coreutils`](https://formulae.brew.sh/formula/coreutils) is required.
+> On Ubuntu `unzip` is required.
 
 Example usage:
 


### PR DESCRIPTION
Update Readme.md adding small add for Ubuntu
Default Ubuntu requires unzip for otel-dotnet-auto-install.sh to work Added note for this requirement

## Why

<!-- Explain why the changes are needed.  -->

Fixes #
added small note about requiring unzip for default ubuntu LTS for otel-doetnet-auto-install.sh to function correctly

## What

<!-- Describe changes proposed in this pull request. -->

add small note about requiring unzip for default ubuntu LTS for otel-doetnet-auto-install.sh to function correctly

## Tests

<!-- Describe how the change was tested (both manual and automated) for reviewers to find edge cases more easily. -->

N/A only documentation

## Checklist

<!-- All items should be verified and marked as done.
     ~~strikethrough~~ if an item doesn't apply to the introduced changes. -->

- [ ] `CHANGELOG.md` is updated.
- [ ] Documentation is updated.
- [ ] New features are covered by tests.
